### PR TITLE
Stop bcbio_validation_workflows from polluting the environment

### DIFF
--- a/NA12878-chr20/run_toil.sh
+++ b/NA12878-chr20/run_toil.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -eu -o pipefail
 #synapse get -r syn9725771
-PROJECT=NA12878-platinum-chr20
+VALIDATION_PROJECT=NA12878-platinum-chr20
 
 # local bcbio install
-bcbio_vm.py cwlrun toil --no-container $PROJECT-workflow -- --logFile $PROJECT-toil.log
+bcbio_vm.py cwlrun toil --no-container $VALIDATION_PROJECT-workflow -- --logFile $VALIDATION_PROJECT-toil.log
 
 # with Docker
-#bcbio_vm.py cwlrun toil $PROJECT-workflow -- --logFile $PROJECT-toil.log
+#bcbio_vm.py cwlrun toil $VALIDATION_PROJECT-workflow -- --logFile $VALIDATION_PROJECT-toil.log


### PR DESCRIPTION
`$PROJECT` is being used in our cluster to manage research projects:

```raijin5 2017-07-02 16:00:56,719 MainThread INFO toil.leader: Starting the main loop
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.
qsub: Error: You are not a member of project NA12878-platinum-chr20. You must be a member of a project to submit a job under that project.```